### PR TITLE
SI-8019 Make Publisher check PartialFunction is defined for Event

### DIFF
--- a/src/main/scala/scala/swing/Publisher.scala
+++ b/src/main/scala/scala/swing/Publisher.scala
@@ -44,7 +44,7 @@ trait Publisher extends Reactor {
   /**
    * Notify all registered reactions.
    */
-  def publish(e: Event) { for (l <- listeners) l(e) }
+  def publish(e: Event) { for (l <- listeners) if (l.isDefinedAt(e)) l(e) }
 
   listenTo(this)
 }


### PR DESCRIPTION
_copied from https://github.com/scala/scala/pull/3205 - @adriaanm points out that this is the current repo for scala-swing_

Reactions are PartialFunctions, so if events come through indiscriminately that the listener is not defined for, errors occur. Eg:

```
Exception in thread "AWT-EventQueue-0" scala.MatchError: FocusGained(scala.swing wrapper scala.swing.TextField
```

A Coursera thread with people affected by this issue: https://class.coursera.org/reactive-001/forum/thread?thread_id=1315

_I've signed the Scala CLA._
