### PR TITLE
SI-8495 - swing.Publisher does not always notify all listeners

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ scalaVersion               := "2.11.0"
 
 snapshotScalaBinaryVersion := "2.11"
 
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.1.4" % "test"
+
 // important!! must come here (why?)
 scalaModuleOsgiSettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion               := "2.11.0"
 
 snapshotScalaBinaryVersion := "2.11"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.1.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.4" % "test"
 
 // important!! must come here (why?)
 scalaModuleOsgiSettings

--- a/src/main/scala/scala/swing/Publisher.scala
+++ b/src/main/scala/scala/swing/Publisher.scala
@@ -44,7 +44,7 @@ trait Publisher extends Reactor {
   /**
    * Notify all registered reactions.
    */
-  def publish(e: Event) { for (l <- listeners) if (l.isDefinedAt(e)) l(e) }
+  def publish(e: Event) { for (l <- listeners.clone()) if ( listeners.containsExists(l) && l.isDefinedAt(e)) l(e) }
 
   listenTo(this)
 }
@@ -168,6 +168,7 @@ private[swing] abstract class RefSet[A <: AnyRef] extends mutable.Set[A] with Si
   def -=(el: A): this.type = { underlying -= Ref(el); purgeReferences(); this }
   def +=(el: A): this.type = { purgeReferences(); underlying += Ref(el); this }
   def contains(el: A): Boolean = { purgeReferences(); underlying.contains(Ref(el)) }
+  def containsExists(el: A): Boolean = {  underlying.contains(Ref(el)) }
   override def size = { purgeReferences(); underlying.size }
 
   protected[this] def removeReference(ref: Reference[A]) { underlying -= ref }

--- a/src/test/scala/scala/swing/test/PublisherTest.scala
+++ b/src/test/scala/scala/swing/test/PublisherTest.scala
@@ -1,0 +1,53 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2014, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.swing.test
+
+import org.scalatest._
+import scala.swing.event.Event
+import scala.swing.{Reactor, Publisher}
+import scala.collection.immutable
+
+
+class PublisherTest extends FunSuite {
+
+  val LoopCount = 1000
+  val ReactorsSize = 1000
+
+  object TstPublisher {
+    case class Destroyed(source: TstPublisher) extends Event
+  }
+
+  class TstPublisher extends Publisher
+
+  class TstReactor(publisher: TstPublisher) extends Reactor {
+    listenTo(publisher)
+
+    var reacted: Int = 0
+
+    reactions += {
+      case TstPublisher.Destroyed(p) if p eq publisher =>
+        reacted = reacted + 1
+        deafTo(publisher)
+    }
+  }
+
+  // Regression test for: https://issues.scala-lang.org/browse/SI-8495
+  test("all listeners should be called exactly once, even if listener state changes during publishing") {
+    (1 until LoopCount) foreach { c =>
+      val publisher = new TstPublisher
+      val reactors = immutable.Seq.fill(ReactorsSize)(new TstReactor(publisher))
+
+      publisher.publish(TstPublisher.Destroyed(publisher))
+
+      reactors.foreach {  r =>
+        assert(r.reacted == 1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://issues.scala-lang.org/browse/SI-8495

On call to publish() will now copy the 'listeners' and check they are still valid before they are called.

Also, a first for scala-swing, a unit test. :-)