### PR TITLE
Update version 2.0 & scala to 2.11 (java7 branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ language: scala
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean update compile test
 scala:
-  - 2.11.0-SNAPSHOT
+  - 2.10.4
+  - 2.11.1
+
 jdk:
   - openjdk7
+  - oraclejdk7
+
 notifications:
   email:
     - adriaan.moors@typesafe.com
+    - andy@hicks.net
 
 # if we get weird timeouts, see https://github.com/spray/spray/pull/233
 # 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 scala-swing (unsupported) [<img src="https://api.travis-ci.org/scala/scala-swing.png?branch=java7"/>](https://travis-ci.org/scala/scala-swing?branch=java7)
 =========
 
-We welcome contributions, but do not actively maintain this library.
-If you're interested in becoming a maintainer, please contact @adriaanm.
+This is now community maintained. If you're interested in helping then contact @adriaanm or @andy1138 
+Questions can asked on the [Google Group](https://groups.google.com/forum/#!forum/scala-swing)
 
 This is a UI library that will wrap most of Java Swing for Scala in a straightforward manner. 
 The widget class hierarchy loosely resembles that of Java Swing. The main differences are:
@@ -27,7 +27,16 @@ The library comprises three main packages:
 - `scala.swing`: All widget classes and traits.
 - `scala.swing.event`: The event hierarchy.
 - `scala.swing.test`: A set of demos.
-    
+
+
+Versions
+---
+  
+- Version 1.xx.xx branch is compiled with java6, 
+- Version 2.xx.xx compiled with java7, targeted to java6.
+
+_Reason for different versions can be found at [SI-3634](https://issues.scala-lang.org/browse/SI-3634)_
+
 
 Notes:
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,12 @@ organization := "org.scala-lang.modules"
 
 name := "scala-swing"
 
-version := "1.0.0-SNAPSHOT"
+version := "2.0.0-SNAPSHOT"
 
-scalaVersion := "2.11.0-M7"
+scalaVersion := "2.11.1"
 
-snapshotScalaBinaryVersion := "2.11.0-M7"
+snapshotScalaBinaryVersion := "2.11.1"
+
+scalacOptions ++= Seq("-deprecation", "-feature", "-target:jvm-1.6")
+
+snapshotScalaBinaryVersion := "2.11"


### PR DESCRIPTION
java7 branch is going to be the main dev branch. 
Upgrading versions numbers so two versions of scala-swing don't get confused.
