### PR TITLE
Table demos with changes to scala.swing.Table.

### DIFF
--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/IntegerEditor.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/IntegerEditor.scala
@@ -115,7 +115,7 @@ class IntegerEditor(min: Int, max: Int) extends DefaultCellEditor(new JFormatted
         integerFormat.parseObject(o.toString)
       } catch {
         case exc: ParseException => {
-          System.err.println("getCellEditorValue: can't parse o: " + o)
+          Console.err.println(s"getCellEditorValue: can't parse o: ${o}")
           null
         }
       }

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableDemo.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scala.swing.examples.tutorials.components
+
+import scala.swing._
+import scala.swing.event.MouseClicked
+import javax.swing.table.DefaultTableModel
+
+/**
+ * Tutorial: How to Use Tables
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/components/table.html]]
+ * 
+ * Source code reference:
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/examples/components/TableDemoProject/src/components/TableDemo.java]]
+ * 
+ * TableDemo.scala requires no other files.
+ *
+ * TableDemo is just like SimpleTableDemo, except that it  uses a custom TableModel.
+ */
+class TableDemo extends GridPanel(1, 0) {
+  private val Debug = false
+
+  val table = new Table(5, 5) {
+    model = new MyTableModel()
+    preferredViewportSize = new Dimension(500, 70)
+  }
+  table.fillsViewportHeight = true
+  if (Debug) {
+    listenTo(table)
+    reactions += {
+      case e: MouseClicked => table.model.asInstanceOf[MyTableModel].printDebugData(table)
+    }
+  }
+
+  //Create the scroll pane and add the table to it.
+  val scrollPane = new ScrollPane(table)
+
+  //Add the scroll pane to this panel.
+  contents += scrollPane
+  class MyTableModel extends DefaultTableModel {
+    val columnNames: Array[String] = Array("First Name",
+      "Last Name",
+      "Sport",
+      "# of Years",
+      "Vegetarian")
+    val data: Array[Array[Any]] = new Array[Array[Any]](5)
+    data(0) = Array("Kathy", "Smith", "Snowboarding", 5, false)
+    data(1) = Array("John", "Doe", "Rowing", 3, true)
+    data(2) = Array("Sue", "Black", "Knitting", 2, false)
+    data(3) = Array("Jane", "White", "Speed reading", 20, true)
+    data(4) = Array("Joe", "Brown", "Pool", 10, false)
+    override def getColumnCount(): Int = { columnNames.length }
+    override def getRowCount(): Int = { if (data == null) 0 else data.length }
+    override def getColumnName(col: Int): String = { columnNames(col) }
+    override def getColumnClass(c: Int): Class[_] = {
+      getValueAt(0, c).getClass();
+    }
+    override def getValueAt(row: Int, col: Int): Object = {
+      col match {
+        case 0 => data(row)(col).asInstanceOf[String]
+        case 1 => data(row)(col).asInstanceOf[String]
+        case 2 => data(row)(col).asInstanceOf[String]
+        case 3 => data(row)(col).asInstanceOf[java.lang.Integer]
+        case 4 => data(row)(col).asInstanceOf[java.lang.Boolean]
+      }
+    }
+    /*
+     * Don't need to implement this method unless your table's
+     * data can change.
+     */
+    override def setValueAt(value: Object, row: Int, col: Int): Unit = {
+      if (Debug) {
+        println("Setting value at " + row + "," + col +
+          " to " + value +
+          " (an instance of " +
+          value.getClass() + ")")
+      }
+      data(row)(col) = value
+      fireTableCellUpdated(row, col)
+      if (Debug) {
+        println("New value of data:")
+        printDebugData(table)
+      }
+    }
+    def printDebugData(table: Table): Unit = {
+      val numRows = table.rowCount
+      val numCols = table.columnCount
+      val model: javax.swing.table.TableModel = table.model
+
+      println("Value of data: ")
+      for (i <- 0 until numRows) {
+        System.out.print("    row " + i + ":")
+        for (j <- 0 until numCols) {
+          print("  " + model.getValueAt(i, j))
+        }
+        println()
+      }
+      println("--------------------------")
+    }
+  }
+}
+
+object TableDemo extends SimpleSwingApplication {
+  lazy val top = new MainFrame() {
+    title = "TableDemo"
+    contents = new TableDemo()
+  }
+}

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableDemo.scala
@@ -81,7 +81,7 @@ class TableDemo extends GridPanel(1, 0) {
     override def getRowCount(): Int = { if (data == null) 0 else data.length }
     override def getColumnName(col: Int): String = { columnNames(col) }
     override def getColumnClass(c: Int): Class[_] = {
-      getValueAt(0, c).getClass();
+      getValueAt(0, c).getClass()
     }
     override def getValueAt(row: Int, col: Int): Object = {
       col match {
@@ -98,10 +98,7 @@ class TableDemo extends GridPanel(1, 0) {
      */
     override def setValueAt(value: Object, row: Int, col: Int): Unit = {
       if (Debug) {
-        println("Setting value at " + row + "," + col +
-          " to " + value +
-          " (an instance of " +
-          value.getClass() + ")")
+        println(s"Setting value at $row,$col to $value (an instance of ${value.getClass()})")
       }
       data(row)(col) = value
       fireTableCellUpdated(row, col)
@@ -117,7 +114,7 @@ class TableDemo extends GridPanel(1, 0) {
 
       println("Value of data: ")
       for (i <- 0 until numRows) {
-        System.out.print("    row " + i + ":")
+        print("    row " + i + ":")
         for (j <- 0 until numCols) {
           print("  " + model.getValueAt(i, j))
         }

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableFTFEditDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableFTFEditDemo.scala
@@ -1,0 +1,142 @@
+
+/*
+ * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scala.swing.examples.tutorials.components
+
+import scala.swing._
+import javax.swing.table.DefaultTableModel
+
+/**
+ * Tutorial: How to Use Tables
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/components/table.html]]
+ * 
+ * Source code references:
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/examples/components/TableFTFEditDemoProject/src/components/TableFTFEditDemo.java]]
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/examples/components/TableFTFEditDemoProject/src/components/IntegerEditor.java]]
+ * 
+ * TableFTFEditDemo.scala requires one other file:
+ *   IntegerEditor.scala
+ *   
+ * This is exactly like TableDemo, except that it uses a
+ * custom cell editor to validate integer input.
+ */
+class TableFTFEditDemo extends GridPanel(1, 0) {
+  private val Debug = false
+  val table = new Table(5, 5) {
+    model = new MyTableModel()
+    preferredViewportSize = new Dimension(500, 70)
+  }
+  table.fillsViewportHeight = true
+
+  //Create the scroll pane and add the table to it.
+  val scrollPane = new ScrollPane(table)
+
+  //Set up stricter input validation for the integer column.
+  val cl = Class.forName("java.lang.Integer")
+  table.defaultEditor_= (cl, new IntegerEditor(0, 100))
+
+  //If we didn't want this editor to be used for other
+  //Integer columns, we'd do this:
+  // table.columnModel.getColumn(3).setCellEditor(
+  //   new IntegerEditor(0, 100));
+
+  //Add the scroll pane to this panel.
+  contents += scrollPane
+  class MyTableModel extends DefaultTableModel {
+    val columnNames: Array[String] = Array("First Name",
+      "Last Name",
+      "Sport",
+      "# of Years",
+      "Vegetarian")
+    val data: Array[Array[Any]] = new Array[Array[Any]](5)
+    data(0) = Array("Kathy", "Smith", "Snowboarding", 5, false)
+    data(1) = Array("John", "Doe", "Rowing", 3, true)
+    data(2) = Array("Sue", "Black", "Knitting", 2, false)
+    data(3) = Array("Jane", "White", "Speed reading", 20, true)
+    data(4) = Array("Joe", "Brown", "Pool", 10, false)
+
+    override def getColumnCount(): Int = { columnNames.length }
+    override def getRowCount(): Int = { if (data == null) 0 else data.length }
+    override def getColumnName(col: Int): String = { columnNames(col) }
+    override def getColumnClass(c: Int): Class[_] = {
+      getValueAt(0, c).getClass();
+    }
+    override def getValueAt(row: Int, col: Int): Object = {
+      col match {
+        case 0 => data(row)(col).asInstanceOf[String]
+        case 1 => data(row)(col).asInstanceOf[String]
+        case 2 => data(row)(col).asInstanceOf[String]
+        case 3 => data(row)(col).asInstanceOf[java.lang.Integer]
+        case 4 => data(row)(col).asInstanceOf[java.lang.Boolean]
+      }
+    }
+    /*
+     * Don't need to implement this method unless your table's
+     * data can change.
+     */
+    override def setValueAt(value: Object, row: Int, col: Int): Unit = {
+      if (Debug) {
+        println("Setting value at " + row + "," + col +
+          " to " + value +
+          " (an instance of " +
+          value.getClass() + ")")
+      }
+      data(row)(col) = value
+      fireTableCellUpdated(row, col)
+      if (Debug) {
+        println("New value of data:")
+        printDebugData(table)
+      }
+    }
+    def printDebugData(table: Table): Unit = {
+      val numRows = table.rowCount
+      val numCols = table.columnCount
+      val model: javax.swing.table.TableModel = table.model
+
+      println("Value of data: ")
+      for (i <- 0 until numRows) {
+        System.out.print("    row " + i + ":")
+        for (j <- 0 until numCols) {
+          print("  " + model.getValueAt(i, j))
+        }
+        println()
+      }
+      println("--------------------------")
+    }
+  }
+}
+
+object TableFTFEditDemo extends SimpleSwingApplication {
+  lazy val top = new MainFrame() {
+    title = "TableFTFEditDemo"
+    contents = new TableFTFEditDemo()
+  }
+}

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableFTFEditDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableFTFEditDemo.scala
@@ -66,7 +66,7 @@ class TableFTFEditDemo extends GridPanel(1, 0) {
   //If we didn't want this editor to be used for other
   //Integer columns, we'd do this:
   // table.columnModel.getColumn(3).setCellEditor(
-  //   new IntegerEditor(0, 100));
+  //   new IntegerEditor(0, 100))
 
   //Add the scroll pane to this panel.
   contents += scrollPane
@@ -87,7 +87,7 @@ class TableFTFEditDemo extends GridPanel(1, 0) {
     override def getRowCount(): Int = { if (data == null) 0 else data.length }
     override def getColumnName(col: Int): String = { columnNames(col) }
     override def getColumnClass(c: Int): Class[_] = {
-      getValueAt(0, c).getClass();
+      getValueAt(0, c).getClass()
     }
     override def getValueAt(row: Int, col: Int): Object = {
       col match {
@@ -104,10 +104,7 @@ class TableFTFEditDemo extends GridPanel(1, 0) {
      */
     override def setValueAt(value: Object, row: Int, col: Int): Unit = {
       if (Debug) {
-        println("Setting value at " + row + "," + col +
-          " to " + value +
-          " (an instance of " +
-          value.getClass() + ")")
+        println(s"Setting value at $row,$col to $value (an instance of ${value.getClass()})")
       }
       data(row)(col) = value
       fireTableCellUpdated(row, col)
@@ -123,7 +120,7 @@ class TableFTFEditDemo extends GridPanel(1, 0) {
 
       println("Value of data: ")
       for (i <- 0 until numRows) {
-        System.out.print("    row " + i + ":")
+        print("    row " + i + ":")
         for (j <- 0 until numCols) {
           print("  " + model.getValueAt(i, j))
         }

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TablePrintDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TablePrintDemo.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scala.swing.examples.tutorials.components
+
+import scala.swing._
+import scala.swing.event.ButtonClicked
+import javax.swing.table.DefaultTableModel
+import java.text.MessageFormat
+
+/**
+ * Tutorial: How to Use Tables
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/components/table.html]]
+ * 
+ * Source code reference:
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/examples/components/TablePrintDemoProject/src/components/TablePrintDemo.java]]
+ * 
+ * TablePrintDemo.scala requires no other files.
+ */
+class TablePrintDemo extends BoxPanel(Orientation.Vertical) {
+  private val Debug = false
+
+  val table = new Table(5, 5) {
+    model = new MyTableModel()
+    preferredViewportSize = new Dimension(500, 70)
+  }
+  table.fillsViewportHeight = true
+  //  if (Debug) {
+  //    listenTo(table)
+  //    reactions += {
+  //      case e: MouseClicked => printDebugData(table)
+  //    }
+  //  }
+
+  //Create the scroll pane and add the table to it.
+  val scrollPane = new ScrollPane(table)
+
+  //Add a print button.
+  val printButton = new Button("Print") {
+    xLayoutAlignment = java.awt.Component.CENTER_ALIGNMENT
+  }
+
+  //Add the scroll pane to this panel.
+  contents += scrollPane
+  contents += printButton
+
+  listenTo(printButton)
+  reactions += {
+    case ButtonClicked(`printButton`) =>
+      val header: MessageFormat = new MessageFormat("Page {0, number, integer}")
+      try {
+        table.print(javax.swing.JTable.PrintMode.FIT_WIDTH, header, null)
+      } catch {
+        case e: java.awt.print.PrinterException =>
+          //sys.err does not have a print method
+          System.err.format("Cannot print %s%n", e.getMessage())
+      }
+  }
+
+  class MyTableModel extends DefaultTableModel {
+    val columnNames: Array[String] = Array("First Name",
+      "Last Name",
+      "Sport",
+      "# of Years",
+      "Vegetarian")
+    val data: Array[Array[Any]] = new Array[Array[Any]](5)
+    data(0) = Array("Kathy", "Smith", "Snowboarding", 5, false)
+    data(1) = Array("John", "Doe", "Rowing", 3, true)
+    data(2) = Array("Sue", "Black", "Knitting", 2, false)
+    data(3) = Array("Jane", "White", "Speed reading", 20, true)
+    data(4) = Array("Joe", "Brown", "Pool", 10, false)
+
+    override def getColumnCount(): Int = { columnNames.length }
+    override def getRowCount(): Int = { if (data == null) 0 else data.length }
+    override def getColumnName(col: Int): String = { columnNames(col) }
+    override def getColumnClass(c: Int): Class[_] = {
+      getValueAt(0, c).getClass();
+    }
+    override def getValueAt(row: Int, col: Int): Object = {
+      col match {
+        case 0 => data(row)(col).asInstanceOf[String]
+        case 1 => data(row)(col).asInstanceOf[String]
+        case 2 => data(row)(col).asInstanceOf[String]
+        case 3 => data(row)(col).asInstanceOf[java.lang.Integer]
+        case 4 => data(row)(col).asInstanceOf[java.lang.Boolean]
+      }
+    }
+    /*
+     * Don't need to implement this method unless your table's
+     * data can change.
+     */
+    override def setValueAt(value: Object, row: Int, col: Int): Unit = {
+      if (Debug) {
+        println("Setting value at " + row + "," + col +
+          " to " + value +
+          " (an instance of " +
+          value.getClass() + ")")
+      }
+      data(row)(col) = value
+      fireTableCellUpdated(row, col)
+      if (Debug) {
+        println("New value of data:")
+        printDebugData(table)
+      }
+    }
+    def printDebugData(table: Table): Unit = {
+      val numRows = table.rowCount
+      val numCols = table.columnCount
+      val model: javax.swing.table.TableModel = table.model
+
+      println("Value of data: ")
+      for (i <- 0 until numRows) {
+        System.out.print("    row " + i + ":")
+        for (j <- 0 until numCols) {
+          print("  " + model.getValueAt(i, j))
+        }
+        println()
+      }
+      println("--------------------------")
+    }
+  }
+
+}
+
+object TablePrintDemo extends SimpleSwingApplication {
+  lazy val top = new MainFrame() {
+    title = "TablePrintDemo"
+    contents = new TablePrintDemo()
+  }
+}

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TablePrintDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TablePrintDemo.scala
@@ -79,8 +79,7 @@ class TablePrintDemo extends BoxPanel(Orientation.Vertical) {
         table.print(javax.swing.JTable.PrintMode.FIT_WIDTH, header, null)
       } catch {
         case e: java.awt.print.PrinterException =>
-          //sys.err does not have a print method
-          System.err.format("Cannot print %s%n", e.getMessage())
+          Console.err.format(s"Cannot print ${e.getMessage()}")
       }
   }
 
@@ -101,7 +100,7 @@ class TablePrintDemo extends BoxPanel(Orientation.Vertical) {
     override def getRowCount(): Int = { if (data == null) 0 else data.length }
     override def getColumnName(col: Int): String = { columnNames(col) }
     override def getColumnClass(c: Int): Class[_] = {
-      getValueAt(0, c).getClass();
+      getValueAt(0, c).getClass()
     }
     override def getValueAt(row: Int, col: Int): Object = {
       col match {
@@ -118,10 +117,7 @@ class TablePrintDemo extends BoxPanel(Orientation.Vertical) {
      */
     override def setValueAt(value: Object, row: Int, col: Int): Unit = {
       if (Debug) {
-        println("Setting value at " + row + "," + col +
-          " to " + value +
-          " (an instance of " +
-          value.getClass() + ")")
+        println(s"Setting value at $row,$col to $value (an instance of ${value.getClass()})")
       }
       data(row)(col) = value
       fireTableCellUpdated(row, col)
@@ -137,7 +133,7 @@ class TablePrintDemo extends BoxPanel(Orientation.Vertical) {
 
       println("Value of data: ")
       for (i <- 0 until numRows) {
-        System.out.print("    row " + i + ":")
+        print("    row " + i + ":")
         for (j <- 0 until numCols) {
           print("  " + model.getValueAt(i, j))
         }

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableSelectionDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableSelectionDemo.scala
@@ -55,7 +55,7 @@ class TableSelectionDemo extends BoxPanel(Orientation.Vertical) {
   table.fillsViewportHeight = true
   table.selectionModel.addListSelectionListener(new RowListener())
   table.columnModel.getSelectionModel().
-    addListSelectionListener(new ColumnListener());
+    addListSelectionListener(new ColumnListener())
   //Create the scroll pane and add the table to it.
   val scrollPane = new ScrollPane(table)
 
@@ -154,16 +154,16 @@ class TableSelectionDemo extends BoxPanel(Orientation.Vertical) {
     output.append("Lead: %d, %d. ".format(
       table.selectionModel.getLeadSelectionIndex(),
       table.columnModel.getSelectionModel().
-        getLeadSelectionIndex()));
-    output.append("Rows:");
+        getLeadSelectionIndex()))
+    output.append("Rows:")
     for (c: Int <- table.selection.rows) {
       output.append(" " + c.asInstanceOf[Int])
     }
-    output.append(". Columns:");
+    output.append(". Columns:")
     for (c: Int <- table.selection.columns) {
       output.append(" " + c.asInstanceOf[Int])
     }
-    output.append(".\n");
+    output.append(".\n")
   }
 
   class RowListener extends ListSelectionListener {
@@ -201,7 +201,7 @@ class TableSelectionDemo extends BoxPanel(Orientation.Vertical) {
     override def getRowCount(): Int = { if (data == null) 0 else data.length }
     override def getColumnName(col: Int): String = { columnNames(col) }
     override def getColumnClass(c: Int): Class[_] = {
-      getValueAt(0, c).getClass();
+      getValueAt(0, c).getClass()
     }
     override def getValueAt(row: Int, col: Int): Object = {
       col match {
@@ -220,9 +220,9 @@ class TableSelectionDemo extends BoxPanel(Orientation.Vertical) {
       //Note that the data/cell address is constant,
       //no matter where the cell appears onscreen.
       if (col < 2) {
-        false;
+        false
       } else {
-        true;
+        true
       }
     }
 

--- a/examples/src/main/scala/scala/swing/examples/tutorials/components/TableSelectionDemo.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/components/TableSelectionDemo.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package scala.swing.examples.tutorials.components
+
+
+
+import scala.swing._
+import scala.swing.event.ButtonClicked
+import javax.swing.event.{ListSelectionEvent, ListSelectionListener}
+import javax.swing.table.DefaultTableModel
+
+/**
+ * Tutorial: How to Use Tables
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/components/table.html]]
+ * 
+ * Source code reference:
+ * [[http://docs.oracle.com/javase/tutorial/uiswing/examples/components/TableSelectionDemoProject/src/components/TableSelectionDemo.java]]
+ * 
+ * TableSelectionDemo.scala requires no other files.
+ */
+class TableSelectionDemo extends BoxPanel(Orientation.Vertical) {
+
+  val table = new Table(5, 5) {
+    model = new MyTableModel()
+    preferredViewportSize = new Dimension(500, 70)
+  }
+  table.fillsViewportHeight = true
+  table.selectionModel.addListSelectionListener(new RowListener())
+  table.columnModel.getSelectionModel().
+    addListSelectionListener(new ColumnListener());
+  //Create the scroll pane and add the table to it.
+  val scrollPane = new ScrollPane(table)
+
+  contents += new Label("Selection Mode")
+
+  val multipleInterval = new RadioButton("Multiple Interval Selection") {
+    selected = true
+  }
+  val single = new RadioButton("Single Selection")
+  val singleInterval = new RadioButton("Single Interval Selection")
+  val buttonGroup = new ButtonGroup() {
+    buttons += multipleInterval
+    buttons += single
+    buttons += singleInterval
+  }
+  contents += multipleInterval
+  contents += single
+  contents += singleInterval
+
+  contents += new Label("Selection Options")
+  val rowCheck = new CheckBox("Row Selection") {
+    selected = true
+  }
+  val columnCheck = new CheckBox("Column Selection")
+  val cellCheck = new CheckBox("Cell Selection") {
+    enabled = false
+  }
+  contents += rowCheck
+  contents += columnCheck
+  contents += cellCheck
+
+  //Add the scroll pane to this panel.
+  contents += scrollPane
+
+  val output = new TextArea(5, 40) {
+    editable = false
+  }
+
+  contents += new ScrollPane(output)
+
+  listenTo(multipleInterval)
+  listenTo(single)
+  listenTo(singleInterval)
+  listenTo(rowCheck)
+  listenTo(columnCheck)
+  listenTo(cellCheck)
+
+  reactions += {
+    case ButtonClicked(`rowCheck`) =>
+      //Scala swing does not allow cell selection to be set independently.
+      if (rowCheck.selected) {
+        table.selection.elementMode = Table.ElementMode.Row
+        columnCheck.selected = false
+        cellCheck.selected = false
+      }
+      else {
+        table.selection.elementMode = Table.ElementMode.None
+      }
+    case ButtonClicked(`columnCheck`) =>
+      //Scala swing does not allow cell selection to be set independently.
+      if (columnCheck.selected) {
+        table.selection.elementMode = Table.ElementMode.Column
+        rowCheck.selected = false
+        cellCheck.selected = false
+      }
+      else {
+        table.selection.elementMode = Table.ElementMode.None
+      }
+    case ButtonClicked(`cellCheck`) =>
+      //Scala swing does not allow cell selection to be set independently.
+      if (cellCheck.selected) {
+        table.selection.elementMode = Table.ElementMode.Cell
+        rowCheck.selected = false
+        columnCheck.selected = false
+      }
+      else {
+        table.selection.elementMode = Table.ElementMode.None
+      }
+    case ButtonClicked(`multipleInterval`) =>
+      table.selection.intervalMode = Table.IntervalMode.MultiInterval
+      //If cell selection is on, turn it off.
+      if (cellCheck.selected) {
+        cellCheck.selected = false
+        cellCheck.enabled = false
+        table.selection.elementMode = Table.ElementMode.None
+      }
+    case ButtonClicked(`singleInterval`) =>
+      table.selection.intervalMode = Table.IntervalMode.SingleInterval
+      cellCheck.enabled = true
+    case ButtonClicked(`single`) =>
+      table.selection.intervalMode = Table.IntervalMode.Single
+      cellCheck.enabled = true
+  }
+
+  def outputSelection(): Unit = {
+    output.append("Lead: %d, %d. ".format(
+      table.selectionModel.getLeadSelectionIndex(),
+      table.columnModel.getSelectionModel().
+        getLeadSelectionIndex()));
+    output.append("Rows:");
+    for (c: Int <- table.selection.rows) {
+      output.append(" " + c.asInstanceOf[Int])
+    }
+    output.append(". Columns:");
+    for (c: Int <- table.selection.columns) {
+      output.append(" " + c.asInstanceOf[Int])
+    }
+    output.append(".\n");
+  }
+
+  class RowListener extends ListSelectionListener {
+    def valueChanged(event: ListSelectionEvent): Unit = {
+      if (!event.getValueIsAdjusting()) {
+        output.append("ROW SELECTION EVENT. ")
+        outputSelection()
+      }
+    }
+  }
+
+  class ColumnListener extends ListSelectionListener {
+    def valueChanged(event: ListSelectionEvent): Unit = {
+      if (!event.getValueIsAdjusting()) {
+        output.append("COLUMN SELECTION EVENT. ")
+        outputSelection()
+      }
+    }
+  }
+
+  class MyTableModel extends DefaultTableModel {
+    val columnNames: Array[String] = Array("First Name",
+      "Last Name",
+      "Sport",
+      "# of Years",
+      "Vegetarian")
+    val data: Array[Array[Any]] = new Array[Array[Any]](5)
+    data(0) = Array("Kathy", "Smith", "Snowboarding", 5, false)
+    data(1) = Array("John", "Doe", "Rowing", 3, true)
+    data(2) = Array("Sue", "Black", "Knitting", 2, false)
+    data(3) = Array("Jane", "White", "Speed reading", 20, true)
+    data(4) = Array("Joe", "Brown", "Pool", 10, false)
+
+    override def getColumnCount(): Int = { columnNames.length }
+    override def getRowCount(): Int = { if (data == null) 0 else data.length }
+    override def getColumnName(col: Int): String = { columnNames(col) }
+    override def getColumnClass(c: Int): Class[_] = {
+      getValueAt(0, c).getClass();
+    }
+    override def getValueAt(row: Int, col: Int): Object = {
+      col match {
+        case 0 => data(row)(col).asInstanceOf[String]
+        case 1 => data(row)(col).asInstanceOf[String]
+        case 2 => data(row)(col).asInstanceOf[String]
+        case 3 => data(row)(col).asInstanceOf[java.lang.Integer]
+        case 4 => data(row)(col).asInstanceOf[java.lang.Boolean]
+      }
+    }
+    /*
+     * Don't need to implement this method unless your table's
+     * editable.
+     */
+    override def isCellEditable(row: Int, col: Int): Boolean = {
+      //Note that the data/cell address is constant,
+      //no matter where the cell appears onscreen.
+      if (col < 2) {
+        false;
+      } else {
+        true;
+      }
+    }
+
+    /*
+     * Don't need to implement this method unless your table's
+     * data can change.
+     */
+    override def setValueAt(value: Object, row: Int, col: Int): Unit = {
+      data(row)(col) = value
+      fireTableCellUpdated(row, col)
+    }
+  }
+}
+
+object TableSelectionDemo extends SimpleSwingApplication {
+  lazy val top = new MainFrame() {
+    title = "TableSelectionDemo"
+    contents = new TableSelectionDemo()
+  }
+}

--- a/examples/src/main/scala/scala/swing/examples/tutorials/layout/BLDComponent.scala
+++ b/examples/src/main/scala/scala/swing/examples/tutorials/layout/BLDComponent.scala
@@ -78,7 +78,7 @@ class BLDComponent(alignmentX: Float, hue: Float, shortSideSize: Int,
     g.drawString(alignmentX.toString, 3, height - 3);
 
     if (printSize) {
-      System.out.println("BLDComponent " + name + ": size is "
+      println("BLDComponent " + name + ": size is "
         + width + "x" + height
         + "; preferred size is "
         + preferredSize.getWidth() + "x"

--- a/src/main/scala/scala/swing/Table.scala
+++ b/src/main/scala/scala/swing/Table.scala
@@ -150,6 +150,7 @@ class Table extends Component with Scrollable.Wrapper {
   def rowHeight_=(x: Int) = peer.setRowHeight(x)
 
   def rowCount = peer.getRowCount
+  def columnCount = peer.getColumnCount
 
   def model = peer.getModel()
   def model_=(x: TableModel) = {
@@ -168,6 +169,10 @@ class Table extends Component with Scrollable.Wrapper {
   def gridColor_=(color: Color) = peer.setGridColor(color)
 
   def preferredViewportSize_=(dim: Dimension) = peer.setPreferredScrollableViewportSize(dim)
+  
+  def fillsViewportHeight = peer.getFillsViewportHeight()
+  def fillsViewportHeight_=(b: Boolean) = peer.setFillsViewportHeight(b)
+  
   //1.6: def fillsViewportHeight: Boolean = peer.getFillsViewportHeight
   //def fillsViewportHeight_=(b: Boolean) = peer.setFillsViewportHeight(b)
 
@@ -299,6 +304,21 @@ class Table extends Component with Scrollable.Wrapper {
   def selectionForeground_=(c: Color) = peer.setSelectionForeground(c)
   def selectionBackground: Color = peer.getSelectionBackground
   def selectionBackground_=(c: Color) = peer.setSelectionBackground(c)
+  
+  def print(): Boolean = print(JTable.PrintMode.FIT_WIDTH)
+  def print(printMode: JTable.PrintMode): Boolean = print(printMode, null, null)
+  def print(printMode: JTable.PrintMode, headerFormat: java.text.MessageFormat, footerFormat: java.text.MessageFormat): Boolean =
+    print(printMode, headerFormat, footerFormat, true, null, false, null)
+  def print(printMode: JTable.PrintMode, headerFormat: java.text.MessageFormat,
+    footerFormat: java.text.MessageFormat, showPrintDialog: Boolean, attr: javax.print.attribute.PrintRequestAttributeSet,
+    interactive: Boolean, service: javax.print.PrintService): Boolean =
+    peer.print(printMode, headerFormat, footerFormat, showPrintDialog, attr, interactive, service)
+    
+  def selectionModel: javax.swing.ListSelectionModel = peer.getSelectionModel
+  def columnModel: javax.swing.table.TableColumnModel = peer.getColumnModel
+  def defaultEditor[A](columnClass: Class[A]): javax.swing.table.TableCellEditor = peer.getDefaultEditor(columnClass)
+  def defaultEditor_=[A](columnClass: Class[A], editor: javax.swing.table.TableCellEditor) =
+    peer.setDefaultEditor(columnClass, editor)
 
   protected val modelListener = new TableModelListener {
     def tableChanged(e: TableModelEvent) = publish(


### PR DESCRIPTION
TableDemo, TableSelectionDemo, TablePrintDemo, and TableFTFEditDemo.
SimpleTableDemo and SimpleTableSelectionDemo are withheld because the Integer
valued columns are not properly editable.

Changes to scala.swing.Table: columnCount, fillsViewportHeight, various print
functions, selectionModel, columnModel, defaultEditor.  The print functions,
especially, need review.
