### PR TITLE
Allow building an existing tag against a new Scala version

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,7 +1,5 @@
 ## Tag Driven Releasing
 
-Copied from https://github.com/scala/scala-java8-compat/commit/4a6cfc97cd95227b86650410e1b632e5ff79335b.
-
 ### Background Reading
 
   - http://docs.travis-ci.com/user/environment-variables/
@@ -14,12 +12,12 @@ To configure tag driven releases from Travis CI.
 
   1. Generate a key pair for this repository with `./admin/genKeyPair.sh`.
      Edit `.travis.yml` and `admin/build.sh` as prompted.
-  2. Publish the public key to https://pgp.mit.edu
-  3. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
+  1. Publish the public key to https://pgp.mit.edu
+  1. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
      Edit `.travis.yml` as prompted.
-  4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
+  1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `.travis.yml` to select which JDK will be used for publishing.
+  1. Edit `.travis.yml` to select which JDK will be used for publishing.
 
 It is important to add comments in .travis.yml to identify the name
 of each environment variable encoded in a `:secure` section.
@@ -30,7 +28,7 @@ form:
 	language: scala
 	env:
 	  global:
-	    - PUBLISH_JDK=openjdk6
+	    - PUBLISH_JDK=oraclejdk8
 	    # PGP_PASSPHRASE
 	    - secure: "XXXXXX"
 	    # SONA_USER
@@ -46,16 +44,18 @@ Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/
 
 ### Testing
 
-  1. Follow the release process below to create a dummy release (e.g. 0.1.0-TEST1).
+  1. Follow the release process below to create a dummy release (e.g., `v0.1.0-TEST1`).
      Confirm that the release was staged to Sonatype but do not release it to Maven
      central. Instead, drop the staging repository.
 
 ### Performing a release
 
-  1. Create a GitHub "Release" (with a corresponding tag) via the GitHub
+  1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
-  2. Travis CI will schedule a build for this release. Review the build logs.
-  3. Log into https://oss.sonatype.org/ and identify the staging repository.
-  4. Sanity check its contents
-  5. Release staging repository to Maven and send out release announcement.
-
+  1. The release will be published using all Scala versions in `build.sbt`'s `crossScalaVersions`.
+     If you need to release it against a different Scala version, include it in the tag
+     name after a `#` (e.g., `v0.1.1#2.13.0-M1`).
+  1. Travis CI will schedule a build for this release. Review the build logs.
+  1. Log into https://oss.sonatype.org/ and identify the staging repository.
+  1. Sanity check its contents.
+  1. Release staging repository to Maven and send out release announcement.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -2,15 +2,33 @@
 
 set -e
 
-# prep environment for publish to sonatype staging if the HEAD commit is tagged
+# Builds of tagged revisions are published to sonatype staging.
 
-# git on travis does not fetch tags, but we have TRAVIS_TAG
-# headTag=$(git describe --exact-match ||:)
+# Travis runs a build on new revisions and on new tags, so a tagged revision is built twice.
+# Builds for a tag have TRAVIS_TAG defined, which we use for identifying tagged builds.
+# Checking the local git clone would not work because git on travis does not fetch tags.
 
-if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
+# The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
+# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
+
+# When a new, binary incompatible Scala version becomes available, a previously released version
+# can be released using that new Scala version by creating a new tag containing the Scala version
+# after a hash, e.g., v1.2.3#2.13.0-M1.
+
+verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
+tagPat="^v$verPat(#$verPat)?$"
+
+if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   echo "Going to release from tag $TRAVIS_TAG!"
-  myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
-  publishVersion='set every version := "'$myVer'"'
+
+  tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
+  publishVersion='set every version := "'$tagVer'"'
+
+  scalaVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
+  if [ "$scalaVer" != "" ]; then
+    publishScalaVersion='set every crossScalaVersions := Seq("'$scalaVer'")'
+  fi
+
   extraTarget="+publish-signed"
   cat admin/gpg.sbt >> project/plugins.sbt
   cp admin/publish-settings.sbt .
@@ -22,4 +40,4 @@ if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt "$publishVersion" clean update +test +publishLocal $extraTarget
+sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget


### PR DESCRIPTION
For tags of the form `v1.2.3-suffix#2.13.0-M1`, the build script
releases version `1.2.3-suffix` using Scala version `2.13.0-M1`.

This allows building an existing tag against a new Scala version.