### PR TITLE
Upgrade scala-module-plugin, use scalaVersionsByJvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 
 env:
   global:
-    - PUBLISH_JDK=openjdk6
     # PGP_PASSPHRASE
     - secure: "MIHv2s6njtXubCzbP/eYXszuO/Y3FADYATZpDtOULZmQHcQ8z+sccQHidyq6hvoK9/I2hRUrc5RIelfA7D32tqP7aF3P9Dq1ZdiWqZYmFKUl6wzJMhgWwnT1RA9Nu67PcNLZGwOe7+55zZpWVNbeTKMe05TzUaaGUgApr9wvS0I="
     # SONA_USER

--- a/admin/README.md
+++ b/admin/README.md
@@ -17,30 +17,39 @@ To configure tag driven releases from Travis CI.
      Edit `.travis.yml` as prompted.
   1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  1. Edit `.travis.yml` to select which JDK will be used for publishing.
+  1. Edit `build.sbt`'s `scalaVersionsByJvm` to select Scala and JVM version combinations that
+     will be used for publishing.
 
-It is important to add comments in .travis.yml to identify the name
+It is important to add comments in `.travis.yml` to identify the name
 of each environment variable encoded in a `:secure` section.
 
-After all of these steps, your .travis.yml should contain config of the
-form:
+After these steps, your `.travis.yml` should contain config of the form:
 
-	language: scala
-	env:
-	  global:
-	    - PUBLISH_JDK=oraclejdk8
-	    # PGP_PASSPHRASE
-	    - secure: "XXXXXX"
-	    # SONA_USER
-	    - secure: "XXXXXX"
-	    # SONA_PASS
-	    - secure: "XXXXXX"
-	script: admin/build.sh
+```
+language: scala
+
+env:
+  global:
+    # PGP_PASSPHRASE
+    - secure: "XXXXXX"
+    # SONA_USER
+    - secure: "XXXXXX"
+    # SONA_PASS
+    - secure: "XXXXXX"
+
+script: admin/build.sh
+
+jdk:
+  - openjdk6
+  - oraclejdk8
+
+notifications:
+  email:
+    - a@b.com
+```
 
 If Sonatype credentials change in the future, step 3 can be repeated
 without generating a new key.
-
-Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/issues/1430)!
 
 ### Testing
 
@@ -52,9 +61,11 @@ Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/
 
   1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
-  1. The release will be published using all Scala versions in `build.sbt`'s `crossScalaVersions`.
-     If you need to release it against a different Scala version, include it in the tag
-     name after a `#` (e.g., `v0.1.1#2.13.0-M1`).
+  1. The release will be published using the Scala and JVM version combinations specified
+     in `scalaVersionsByJvm` in `build.sbt`.
+     - If you need to release against a different Scala version, include the Scala version
+       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
+       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
   1. Travis CI will schedule a build for this release. Review the build logs.
   1. Log into https://oss.sonatype.org/ and identify the staging repository.
   1. Sanity check its contents.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -12,21 +12,31 @@ set -e
 # version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
 
 # When a new, binary incompatible Scala version becomes available, a previously released version
-# can be released using that new Scala version by creating a new tag containing the Scala version
-# after a hash, e.g., v1.2.3#2.13.0-M1.
+# can be released using that new Scala version by creating a new tag containing the Scala and the
+# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
+# `.travis.yml`, otherwise the required build doesn't run.
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
-tagPat="^v$verPat(#$verPat)?$"
+tagPat="^v$verPat(#$verPat#[0-9]+)?$"
 
-if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
-  echo "Going to release from tag $TRAVIS_TAG!"
+if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
+  currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
 
   tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
   publishVersion='set every version := "'$tagVer'"'
 
-  scalaVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
-  if [ "$scalaVer" != "" ]; then
-    publishScalaVersion='set every crossScalaVersions := Seq("'$scalaVer'")'
+  scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
+  if [ "$scalaAndJvmVer" != "" ]; then
+    scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
+    jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
+    if [ "$jvmVer" != "$currentJvmVer" ]; then
+      echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
+      exit 0
+    fi
+    publishScalaVersion='set every scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
+    echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
+  else
+    echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
   fi
 
   extraTarget="+publish-signed"

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,19 @@
-import com.typesafe.tools.mima.plugin.{MimaPlugin, MimaKeys}
-
 scalaModuleSettings
 
-name                       := "scala-swing"
+name    := "scala-swing"
+version := "1.0.3-SNAPSHOT"
 
-version                    := "1.0.3-SNAPSHOT"
+scalaVersionsByJvm := {
+  val vs = List("2.11.11", "2.10.6")
 
-scalaVersion               := crossScalaVersions.value.head
+  // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
+  Map(
+    6 -> vs.map(_ -> true),
+    7 -> vs.map(_ -> false),
+    8 -> vs.map(_ -> false)
+  )
+}
 
-crossScalaVersions         := Seq("2.11.6", "2.12.0-M1", "2.10.5")
-
-// important!! must come here (why?)
-scalaModuleOsgiSettings
-
-OsgiKeys.exportPackage     := Seq(s"scala.swing.*;version=${version.value}")
+OsgiKeys.exportPackage := Seq(s"scala.swing.*;version=${version.value}")
 
 mimaPreviousVersion := Some("1.0.1")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.3")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.6")


### PR DESCRIPTION
- Update scala-module-plugin to 1.0.6
- Use scalaVersionsByJvm to set crossScalaVersions and scalaVersion
- scalaModuleOsgiSettings is now enabled by the plugin
- Require the JVM version when building an old release against a new Scala
  version by adding it to the tag, e.g., v0.1.2#2.13.0-M1#8