### PR TITLE
bump version numbers of scala, sbt and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ scalaModuleSettings
 
 name               := "scala-swing"
 
-version            := "2.0.1-SNAPSHOT"
+version            := "2.0.2-SNAPSHOT"
 
 scalacOptions      ++= Seq("-deprecation", "-feature")
 
 // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
 scalaVersionsByJvm in ThisBuild := Map(
-  8 -> List("2.11.11", "2.12.2", "2.13.0-M2").map(_ -> true)
+  8 -> List("2.11.12", "2.12.4", "2.13.0-M3").map(_ -> true)
 )
 
 OsgiKeys.exportPackage := Seq(s"scala.swing.*;version=${version.value}")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.13")


### PR DESCRIPTION
Including scala-swing itself: 2.0.1 has been released already.