### PR TITLE
addresses table sorting issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ scalaModuleSettings
 
 name               := "scala-swing"
 
-version            := "2.0.3-SNAPSHOT"
+version            := "2.0.4-SNAPSHOT"
 
 scalacOptions      ++= Seq("-deprecation", "-feature")
 
 // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
 scalaVersionsByJvm in ThisBuild := Map(
-  8 -> List("2.11.12", "2.12.4", "2.13.0-M3").map(_ -> true)
+  8 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> true)
 )
 
 OsgiKeys.exportPackage := Seq(s"scala.swing.*;version=${version.value}")
@@ -28,7 +28,7 @@ lazy val swing = project.in(file("."))
     }
   )
 
-lazy val examples = project.in( file("examples") )
+lazy val examples = project.in(file("examples"))
   .dependsOn(swing)
   .settings(
     scalaVersion := (scalaVersion in swing).value,
@@ -36,7 +36,7 @@ lazy val examples = project.in( file("examples") )
     fork := true
   )
 
-lazy val uitest = project.in( file("uitest") )
+lazy val uitest = project.in(file("uitest"))
   .dependsOn(swing)
   .settings(
     scalaVersion := (scalaVersion in swing).value,

--- a/src/main/scala/scala/swing/Font.scala
+++ b/src/main/scala/scala/swing/Font.scala
@@ -1,0 +1,61 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.swing
+
+import java.awt.{Font => JFont}
+
+object Font {
+  def apply(name: String, style: Style.Value, size: Int): Font =
+    new JFont(name, style.id, size)
+
+  /** A String constant for the canonical family name of the
+    * logical font "Dialog". It is useful in Font construction
+    * to provide compile-time verification of the name.
+    */
+  val Dialog: String = JFont.DIALOG
+
+  /** A String constant for the canonical family name of the
+    * logical font "DialogInput". It is useful in Font construction
+    * to provide compile-time verification of the name.
+    */
+  val DialogInput: String = JFont.DIALOG_INPUT
+
+  /** A String constant for the canonical family name of the
+    * logical font "SansSerif". It is useful in Font construction
+    * to provide compile-time verification of the name.
+    */
+  val SansSerif: String = JFont.SANS_SERIF
+
+  /** A String constant for the canonical family name of the
+    * logical font "Serif". It is useful in Font construction
+    * to provide compile-time verification of the name.
+    */
+  val Serif: String = JFont.SERIF
+
+  /** A String constant for the canonical family name of the
+    * logical font "Monospaced". It is useful in Font construction
+    * to provide compile-time verification of the name.
+    */
+  val Monospaced: String = JFont.MONOSPACED
+
+  // Constants to be used for styles. Can be combined to mix styles.
+
+  object Style extends Enumeration {
+    val Plain     : Style.Value = Value(JFont.PLAIN)
+    val Bold      : Style.Value = Value(JFont.BOLD)
+    val Italic    : Style.Value = Value(JFont.ITALIC)
+    val BoldItalic: Style.Value = Value(JFont.BOLD | JFont.ITALIC)
+  }
+
+  // for convenience, have these values also directly in the `Font` name space
+  val Plain     : Style.Value = Style.Plain
+  val Bold      : Style.Value = Style.Bold
+  val Italic    : Style.Value = Style.Italic
+  val BoldItalic: Style.Value = Style.BoldItalic
+}

--- a/src/test/scala/scala/swing/Issue73.scala
+++ b/src/test/scala/scala/swing/Issue73.scala
@@ -26,5 +26,7 @@ class Issue73 extends FlatSpec with Matchers {
     Table.IntervalMode
     event.Key
     event.Key.Location
+
+    Font.Style
   }
 }

--- a/uitest/src/main/scala/scala/swing/uitest/Issue47.scala
+++ b/uitest/src/main/scala/scala/swing/uitest/Issue47.scala
@@ -1,0 +1,67 @@
+package scala.swing
+package uitest
+
+/** Example application to verify that table row sorting
+  * and column reordering work correctly.
+  */
+object Issue47 extends SimpleSwingApplication {
+  lazy val top: Frame = {
+    val data0 = Array(
+      Array("Schaeffer" , 1910, 1995),
+      Array("Sun Ra"    , 1914, 1993),
+      Array("Oram"      , 1925, 2003),
+      Array("Oliveros"  , 1932, 2016)
+    )
+
+    val cn  = Seq("Name", "Born", "Died")
+    val t   = new Table(data0, cn)
+    val st  = new ScrollPane(t)
+    t.autoCreateRowSorter = true
+
+    val ggAsc   = new ToggleButton("Ascending")
+    ggAsc.selected = true
+    val ggSort  = cn.zipWithIndex.map { case (n, ci) => Button(n)(t.sort(ci, ascending = ggAsc.selected)) }
+    val pSort   = new FlowPanel(new Label("Sort by:") +: ggSort :+ ggAsc: _*)
+
+    val ggSelected = new TextArea(3, 40) {
+      lineWrap  = true
+      editable  = false
+      font      = Font(Font.Monospaced, Font.Plain, 12)
+    }
+
+    val pSelected = new FlowPanel(new Label("Selection:"), ggSelected)
+
+    t.selection.elementMode = Table.ElementMode.Cell
+    t.listenTo(t.selection)
+
+    def captureSelection() = t.selection.cells.toList.sorted
+
+    def toModel(in: List[(Int, Int)]): List[(Int, Int)] = in.map { case (row, col) =>
+      t.viewToModelRow(row) -> t.viewToModelColumn(col)
+    }
+
+    var lastSel = List.empty[(Int, Int)]
+
+    t.reactions += {
+      case _: event.TableRowsSelected | _: event.TableColumnsSelected =>
+      val newSel = captureSelection()
+      if (lastSel != newSel) {
+        lastSel = newSel
+        val mSel    = toModel(newSel)
+        val data    = newSel.map { case (row, col) => t.apply(row = row, column = col) }
+        val viewS   = newSel.mkString("View : ", " ; ", "\n")
+        val modelS  = mSel  .mkString("Model: ", " ; ", "\n")
+        val dataS   = data.mkString("Data : ", " ; ", "")
+        ggSelected.text = s"$viewS$modelS$dataS"
+      }
+    }
+
+    new MainFrame {
+      contents = new BoxPanel(Orientation.Vertical) {
+        contents += st
+        contents += pSort
+        contents += pSelected
+      }
+    }
+  }
+}

--- a/uitest/src/main/scala/scala/swing/uitest/SI7597.scala
+++ b/uitest/src/main/scala/scala/swing/uitest/SI7597.scala
@@ -20,7 +20,7 @@ import scala.swing._
  * (expanded to include other showXXXDialog dialogs )
  */
 object SI7597 extends SimpleSwingApplication {
-  def top = new MainFrame {
+  def top: Frame = new MainFrame {
     title = "SI7597 showXXXDialog tests"
     size = new Dimension(900, 200)
 


### PR DESCRIPTION
- bump version to 2.0.4-SNAPSHOT (mima binary compat checks)
- add `Font` object, because having `scala.swing._` in scope means we
  cannot use static methods of `java.awt.Font` any longer.
- add some documentation to `Table`
- add another constructor with table-model to `Table`
- add a few missing methods to `Table` (`rowMargin`, `viewToModelRow`,
  `modelToViewRow`, `autoCreateRowSorter`, `updateSelectionOnSort`)
- fix `apply` and `update` to convert between row model and view
- add programmatic `sort` method.
- fixes #30, fixes #47, fixes #62
- add uitest to verify sorting and converting indices works correctly