### PR TITLE
remove stray characters in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,3 @@ Current changes are being made on the `2.0.x` branch.
 ## Known Issues
 
 - Visual appearance of combo boxes using the GTK LaF is broken on JDKs < 1.7b30. This is a Java Swing problem.
-whe


### PR DESCRIPTION
perhaps some text is missing here? if no one knows what text might be missing, then I guess we should just drop the stray characters.