### PR TITLE
allow building on JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ jdk: oraclejdk8
 notifications:
   email:
     - adriaan.moors@lightbend.com
+    - seth.tisue@lightbend.com
     - andy@hicks.net

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ scalacOptions      ++= Seq("-deprecation", "-feature")
 scalaVersionsByJvm in ThisBuild := Map(
    8 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> true),
    9 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false),
-  10 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false)
+  10 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false),
+  11 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false)
 )
 
 OsgiKeys.exportPackage := Seq(s"scala.swing.*;version=${version.value}")


### PR DESCRIPTION
note that the ambition level at present doesn't extend to adding
JDK 9 or 10 or 11 to the Travis-CI matrix.  we just want to be
able to build scala-swing in the Scala community build on JDK 11,
and this change is necessary for that.