### PR TITLE
Types align on M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,16 @@ name               := "scala-swing"
 
 version            := "2.0.4-SNAPSHOT"
 
-scalacOptions      ++= Seq("-deprecation", "-feature")
+scalacOptions      ++= Seq("-deprecation", "-feature", "-Xlint")
+
+crossScalaVersions := Seq("2.12.8", "2.13.0-M5")
 
 // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
 scalaVersionsByJvm in ThisBuild := Map(
-   8 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> true),
-   9 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false),
-  10 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false),
-  11 -> List("2.11.12", "2.12.6", "2.13.0-M3").map(_ -> false)
+   8 -> List("2.11.12", "2.12.6", "2.13.0-M5").map(_ -> true),
+   9 -> List("2.11.12", "2.12.6", "2.13.0-M5").map(_ -> false),
+  10 -> List("2.11.12", "2.12.6", "2.13.0-M5").map(_ -> false),
+  11 -> List("2.11.12", "2.12.6", "2.13.0-M5").map(_ -> false)
 )
 
 OsgiKeys.exportPackage := Seq(s"scala.swing.*;version=${version.value}")
@@ -25,10 +27,7 @@ shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project
 
 lazy val swing = project.in(file("."))
   .settings(
-    libraryDependencies += {
-      val v = if (scalaVersion.value == "2.13.0-M3") "3.0.5-M1" else "3.0.5"
-      "org.scalatest" %% "scalatest" % v % "test"
-    }
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.6-SNAP5" % Test
   )
 
 lazy val examples = project.in(file("examples"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
 sbt.version=0.13.17
+#sbt.version=1.2.7

--- a/src/main/scala-2.12/scala/swing/MutableShim.scala
+++ b/src/main/scala-2.12/scala/swing/MutableShim.scala
@@ -1,0 +1,56 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2018, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.swing
+
+import scala.collection.mutable
+
+/**
+ * Shims for changing collections API.
+ */
+protected[swing] trait MutableBufferShim[A] extends mutable.Buffer[A] {
+
+  override final def +=(a: A): this.type = addOne(a)
+  override final def +=:(a: A): this.type = prepend(a)
+
+  override final def -=(a: A): this.type = subtractOne(a)
+
+  // Growable
+  def addOne(a: A): this.type
+
+  // Shrinkable, defined in terms of indexOf and remove
+  def subtractOne(a: A): this.type = super.-=(a)
+
+  def prepend(a: A): this.type
+}
+
+protected[swing] trait MutableSetShim[A] extends mutable.Set[A] {
+
+  override final def +=(a: A): this.type = addOne(a)
+
+  override final def -=(a: A): this.type = subtractOne(a)
+
+  // Growable
+  def addOne(a: A): this.type
+
+  // Shrinkable
+  def subtractOne(a: A): this.type
+}
+
+protected[swing] trait MutableMapShim[K, V] extends mutable.Map[K, V] {
+
+  override final def +=(kv: (K, V)): this.type = addOne(kv)
+
+  override final def -=(k: K): this.type = subtractOne(k)
+
+  // Growable
+  def addOne(kv: (K, V)): this.type
+
+  // Shrinkable, defined in terms of indexOf and remove
+  def subtractOne(k: K): this.type
+}

--- a/src/main/scala-2.13.0-M5/scala/swing/MutableShim.scala
+++ b/src/main/scala-2.13.0-M5/scala/swing/MutableShim.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2018, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.swing
+
+import scala.collection.mutable
+
+/**
+ * Shims for changing collections API.
+ */
+protected[swing] trait MutableBufferShim[A] extends mutable.Buffer[A] {
+  override def insert(i: Int, a: A) = insertAt(i, a)
+  protected def insertAt(i: Int, a: A): Unit
+
+  override def insertAll(n: Int, elems: IterableOnce[A]): Unit = insertAllImpl(n, elems.iterator)
+  def insertAllImpl(n: Int, elems: Iterator[A]): Unit
+
+  override def patchInPlace(from: Int, patch: scala.collection.Seq[A], replaced: Int) = {
+    this
+  }
+
+  override def remove(idx: Int, count: Int) = {
+    require(count >= 0)
+    var n = 0
+    while (n < count) {
+      remove(idx + n)
+      n += 1
+    }
+  }
+}
+
+protected[swing] trait MutableSetShim[A] extends mutable.Set[A] {
+  def clear(): Unit = iterator.toList.foreach(remove)
+}
+
+protected[swing] trait MutableMapShim[K, V] extends mutable.Map[K, V]

--- a/src/main/scala-2.13/scala/swing/MutableShim.scala
+++ b/src/main/scala-2.13/scala/swing/MutableShim.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2007-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2018, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -8,15 +8,13 @@
 
 package scala.swing
 
-import javax.swing.JToggleButton
+import scala.collection.mutable.{Growable, Shrinkable}
 
 /**
- * A two state button with a push button like user interface.
- * Usually used in tool bars.
- *
- * @see javax.swing.JToggleButton
+ * Shims for changing collections API.
  */
-class ToggleButton(text0: String) extends AbstractButton {
-  override lazy val peer: JToggleButton = new JToggleButton(text0) with SuperMixin
-  def this() = this("")
-}
+protected[swing] trait MutableBufferShim[A] extends mutable.Buffer[A]
+
+protected[swing] trait MutableSetShim[A] extends mutable.Set[A]
+
+protected[swing] trait MutableMapShim[K, V] extends mutable.Map[K, V]

--- a/src/main/scala/scala/swing/BufferWrapper.scala
+++ b/src/main/scala/scala/swing/BufferWrapper.scala
@@ -8,12 +8,12 @@
 
 package scala.swing
 
-import scala.collection.{Iterator, mutable}
+import scala.collection.mutable.Buffer
 
 /**
  * Default partial implementation for buffer adapters.
  */
-protected[swing] abstract class BufferWrapper[A] extends mutable.Buffer[A] { outer =>
+protected[swing] abstract class BufferWrapper[A] extends Buffer[A] with MutableBufferShim[A] { outer =>
   def clear(): Unit = for (_ <- 0 until length) remove(0)
 
   def update(n: Int, a: A): Unit = {
@@ -28,10 +28,17 @@ protected[swing] abstract class BufferWrapper[A] extends mutable.Buffer[A] { out
       i += 1
     }
   }
+  def insertAllImpl(n: Int, elems: Iterator[A]): Unit = {
+    var i = n
+    for (el <- elems) {
+      insertAt(i, el)
+      i += 1
+    }
+  }
 
   protected def insertAt(n: Int, a: A): Unit
 
-  def +=:(a: A): this.type = { insertAt(0, a); this }
+  def prepend(a: A): this.type = { insertAt(0, a); this }
 
-  def iterator: Iterator[A] = Iterator.range(0,length).map(apply)
+  def iterator: Iterator[A] = Iterator.range(0, length).map(apply)
 }

--- a/src/main/scala/scala/swing/Button.scala
+++ b/src/main/scala/scala/swing/Button.scala
@@ -8,7 +8,7 @@
 
 package scala.swing
 
-import javax.swing._
+import javax.swing.JButton
 
 object Button {
   def apply(text0: String)(op: => Unit) = new Button(Action(text0)(op))

--- a/src/main/scala/scala/swing/ButtonGroup.scala
+++ b/src/main/scala/scala/swing/ButtonGroup.scala
@@ -19,9 +19,9 @@ import scala.collection.mutable
 class ButtonGroup(initialButtons: AbstractButton*) {
   val peer: javax.swing.ButtonGroup = new javax.swing.ButtonGroup
 
-  val buttons: mutable.Set[AbstractButton] = new mutable.Set[AbstractButton] {
-    def -=(b: AbstractButton): this.type = { peer.remove(b.peer); this }
-    def +=(b: AbstractButton): this.type = { peer.add(b.peer); this }
+  val buttons: mutable.Set[AbstractButton] = new mutable.Set[AbstractButton] with MutableSetShim[AbstractButton] {
+    override def subtractOne(b: AbstractButton): this.type = { peer.remove(b.peer); this }
+    override def addOne(b: AbstractButton): this.type = { peer.add(b.peer); this }
     def contains(b: AbstractButton): Boolean = this.iterator.contains(b)
     override def size: Int = peer.getButtonCount
     def iterator: Iterator[AbstractButton] = new Iterator[AbstractButton] {

--- a/src/main/scala/scala/swing/CheckBox.scala
+++ b/src/main/scala/scala/swing/CheckBox.scala
@@ -10,7 +10,7 @@
 
 package scala.swing
 
-import javax.swing._
+import javax.swing.JCheckBox
 
 /**
  * Two state button that can either be checked or unchecked.

--- a/src/main/scala/scala/swing/Container.scala
+++ b/src/main/scala/scala/swing/Container.scala
@@ -10,7 +10,7 @@
 
 package scala.swing
 
-import scala.swing.event._
+import scala.swing.event.{ComponentAdded, ComponentRemoved}
 
 object Container {
   /**
@@ -31,7 +31,7 @@ object Container {
         UIElement.cachedWrapper[Component](c)
       }
       protected def insertAt(n: Int, c: Component): Unit = peer.add(c.peer, n)
-      def +=(c: Component): this.type = { peer.add(c.peer) ; this }
+      def addOne(c: Component): this.type = { peer.add(c.peer) ; this }
       def length: Int = peer.getComponentCount
       def apply(n: Int): Component = UIElement.cachedWrapper[Component](peer.getComponent(n))
     }

--- a/src/main/scala/scala/swing/LayoutContainer.scala
+++ b/src/main/scala/scala/swing/LayoutContainer.scala
@@ -54,9 +54,9 @@ trait LayoutContainer extends Container.Wrapper {
    *
    * also ensures that myComponent is properly added to this container.
    */
-  def layout: mutable.Map[Component, Constraints] = new mutable.Map[Component, Constraints] {
-    def -= (c: Component): this.type = { _contents -= c; this }
-    def += (cl: (Component, Constraints)): this.type = { update(cl._1, cl._2); this }
+  def layout: mutable.Map[Component, Constraints] = new mutable.Map[Component, Constraints] with MutableMapShim[Component, Constraints] {
+    def subtractOne(c: Component): this.type = { _contents -= c; this }
+    def addOne(cl: (Component, Constraints)): this.type = { update(cl._1, cl._2); this }
 
     override def update(c: Component, l: Constraints): Unit = {
       val (v, msg) = areValid(l)

--- a/src/main/scala/scala/swing/ListView.scala
+++ b/src/main/scala/scala/swing/ListView.scala
@@ -14,6 +14,8 @@ import event._
 import javax.swing._
 import javax.swing.event._
 
+import scala.collection.JavaConverters._
+
 object ListView {
   /**
    * The supported modes of user selections.
@@ -179,9 +181,7 @@ class ListView[A] extends Component {
    * The current item selection.
    */
   object selection extends Publisher {
-    protected abstract class Indices[B](a: => Seq[B]) extends scala.collection.mutable.Set[B] {
-      def -=(n: B): this.type
-      def +=(n: B): this.type
+    protected abstract class Indices[B](a: => Seq[B]) extends scala.collection.mutable.Set[B] with MutableSetShim[B] {
       def contains(n: B): Boolean = a.contains(n)
       override def size: Int = a.length
       def iterator: Iterator[B] = a.iterator
@@ -194,16 +194,14 @@ class ListView[A] extends Component {
      * The indices of the currently selected items.
      */
     object indices extends Indices(peer.getSelectedIndices) {
-      def -=(n: Int): this.type = { peer.removeSelectionInterval(n,n); this }
-      def +=(n: Int): this.type = { peer.addSelectionInterval(n,n); this }
+      def subtractOne(n: Int): this.type = { peer.removeSelectionInterval(n,n); this }
+      def addOne(n: Int): this.type = { peer.addSelectionInterval(n,n); this }
     }
 
     /**
      * The currently selected items.
      */
-    object items extends scala.collection.SeqProxy[A] {
-      def self = peer.getSelectedValues.map(_.asInstanceOf[A])
-    }
+    val items: Seq[A] = peer.getSelectedValuesList.asScala
 
     def intervalMode: IntervalMode.Value = IntervalMode(peer.getSelectionModel.getSelectionMode)
     def intervalMode_=(m: IntervalMode.Value): Unit = peer.getSelectionModel.setSelectionMode(m.id)

--- a/src/main/scala/scala/swing/Menu.scala
+++ b/src/main/scala/scala/swing/Menu.scala
@@ -9,7 +9,7 @@
 package scala.swing
 
 import scala.collection.mutable
-import javax.swing._
+import javax.swing.{JMenu, JMenuBar, JMenuItem, JRadioButtonMenuItem, JCheckBoxMenuItem}
 
 object MenuBar {
   case object NoMenuBar extends MenuBar

--- a/src/main/scala/scala/swing/Publisher.scala
+++ b/src/main/scala/scala/swing/Publisher.scala
@@ -132,14 +132,14 @@ private[swing] class StrongReference[+T <: AnyRef](value: T) extends Reference[T
     override def toString: String = get.map(_.toString).getOrElse("<deleted>")
     def clear(): Unit = { ref = None }
     def enqueue(): Boolean = false
-    def isEnqueued(): Boolean = false
+    def isEnqueued: Boolean = false
   }
 
 abstract class RefBuffer[A <: AnyRef] extends mutable.Buffer[A] with SingleRefCollection[A] { self =>
   protected val underlying: mutable.Buffer[Reference[A]]
 
-  def +=(el: A): this.type = { purgeReferences(); underlying += Ref(el); this }
-  def +=:(el: A): this.type = { purgeReferences(); Ref(el) +=: underlying; this }
+  def addOne(el: A): this.type = { purgeReferences(); underlying += Ref(el); this }
+  def prependOne(el: A): this.type = { purgeReferences(); Ref(el) +=: underlying; this }
   def remove(el: A): Unit = { underlying -= Ref(el); purgeReferences(); }
   def remove(n: Int): A = { val el = apply(n); remove(el); el }
   def insertAll(n: Int, iter: Iterable[A]): Unit = {
@@ -162,11 +162,11 @@ abstract class RefBuffer[A <: AnyRef] extends mutable.Buffer[A] with SingleRefCo
   protected[this] def removeReference(ref: Reference[A]): Unit = { underlying -= ref }
 }
 
-private[swing] abstract class RefSet[A <: AnyRef] extends mutable.Set[A] with SingleRefCollection[A] { self =>
+private[swing] abstract class RefSet[A <: AnyRef] extends mutable.Set[A] with MutableSetShim[A] with SingleRefCollection[A] { self =>
   protected val underlying: mutable.Set[Reference[A]]
 
-  def -=(el: A): this.type = { underlying -= Ref(el); purgeReferences(); this }
-  def +=(el: A): this.type = { purgeReferences(); underlying += Ref(el); this }
+  def subtractOne(el: A): this.type = { underlying -= Ref(el); purgeReferences(); this }
+  def addOne(el: A): this.type = { purgeReferences(); underlying += Ref(el); this }
   def contains(el: A): Boolean = { purgeReferences(); underlying.contains(Ref(el)) }
   override def size: Int = { purgeReferences(); underlying.size }
 

--- a/src/main/scala/scala/swing/Slider.scala
+++ b/src/main/scala/scala/swing/Slider.scala
@@ -52,9 +52,10 @@ class Slider extends Component with Orientable.Wrapper with Publisher {
   def adjusting: Boolean = peer.getValueIsAdjusting
 
   def labels: scala.collection.Map[Int, Label] = {
-    import scala.collection.convert.WrapAsScala._
-    val labelTable = peer.getLabelTable.asInstanceOf[java.util.Map[Int, JLabel]]
-    labelTable.mapValues(v => UIElement.cachedWrapper[Label](v))
+    import scala.collection.JavaConverters._
+    val labelTable = peer.getLabelTable.asInstanceOf[java.util.Map[Int, JLabel]].asScala
+    //labelTable.mapValues(v => UIElement.cachedWrapper[Label](v)).toMap
+    labelTable.map { case (k,v) => (k, UIElement.cachedWrapper[Label](v)) }
   }
   def labels_=(l: scala.collection.Map[Int, Label]): Unit = {
     // TODO: do some lazy wrapping

--- a/src/main/scala/scala/swing/TabbedPane.scala
+++ b/src/main/scala/scala/swing/TabbedPane.scala
@@ -96,7 +96,7 @@ class TabbedPane extends Component with Publisher {
       peer.insertTab(t.title, null, t.content.peer, t.tip, n)
     }
 
-    def +=(t: Page): this.type = { t.parent = TabbedPane.this; peer.addTab(t.title, null, t.content.peer, t.tip); this }
+    def addOne(t: Page): this.type = { t.parent = TabbedPane.this; peer.addTab(t.title, null, t.content.peer, t.tip); this }
     def length: Int = peer.getTabCount
     def apply(n: Int) = new Page(TabbedPane.this, peer.getTitleAt(n),
       UIElement.cachedWrapper[Component](peer.getComponentAt(n).asInstanceOf[javax.swing.JComponent]),

--- a/src/main/scala/scala/swing/TextField.scala
+++ b/src/main/scala/scala/swing/TextField.scala
@@ -10,9 +10,9 @@
 
 package scala.swing
 
-import event._
-import javax.swing._
-import java.awt.event._
+import event.EditDone
+import javax.swing.{InputVerifier, JComponent, JTextField}
+import java.awt.event.FocusAdapter
 
 
 /*object TextField {

--- a/src/main/scala/scala/swing/package.scala
+++ b/src/main/scala/scala/swing/package.scala
@@ -14,6 +14,8 @@ package object swing {
   type Image      = java.awt.Image
   type Font       = java.awt.Font
 
+  type Seq[A]     = scala.collection.Seq[A]
+
   implicit lazy val reflectiveCalls     = scala.language.reflectiveCalls
   implicit lazy val implicitConversions = scala.language.implicitConversions
 


### PR DESCRIPTION
Adapt some imports, add shims for change to Growable/Shrinkable, where `+=` is now final and `addOne` is the template method. Shims should be cleaned up and tested.

Tried it out on House of Mirrors, which I couldn't get to compile on 2.9.x any more, but with an import tweak and workaround XML code that was made private in 2011, it runs. Will check how much it exercises.

Fixes scala/scala-swing#84