### PR TITLE
support for Scala 2.13.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: scala
 
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,11 @@ scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature")
 
 // Map[JvmMajorVersion, List[(ScalaVersion, UseForPublishing)]]
 scalaVersionsByJvm in ThisBuild := Map(
-   8 -> List("2.11.12", "2.12.8", "2.13.0-RC1").map(_ -> true),
-   9 -> List("2.11.12", "2.12.8", "2.13.0-RC1").map(_ -> false),
-  10 -> List("2.11.12", "2.12.8", "2.13.0-RC1").map(_ -> false),
-  11 -> List("2.11.12", "2.12.8", "2.13.0-RC1").map(_ -> false),
-  12 -> List("2.11.12", "2.12.8", "2.13.0-RC1").map(_ -> false)
+   8 -> List("2.11.12", "2.12.8", "2.13.0-RC2").map(_ -> true),
+   9 -> List("2.11.12", "2.12.8", "2.13.0-RC2").map(_ -> false),
+  10 -> List("2.11.12", "2.12.8", "2.13.0-RC2").map(_ -> false),
+  11 -> List("2.11.12", "2.12.8", "2.13.0-RC2").map(_ -> false),
+  12 -> List("2.11.12", "2.12.8", "2.13.0-RC2").map(_ -> false)
 )
 
 scalaVersion in ThisBuild := "2.12.8"
@@ -29,7 +29,11 @@ shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project
 lazy val swing = project.in(file("."))
   .settings(
     libraryDependencies += {
-      "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test
+      if (scalaVersion.value == "2.13.0-RC2") {
+        "org.scalatest" % "scalatest_2.13.0-RC1" % "3.0.8-RC2" % Test  // it works
+      } else {
+        "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test
+      }
     },
     // Adds a `src/main/scala-2.13+` source directory for Scala 2.13 and newer
     // and  a `src/main/scala-2.13-` source directory for Scala version older than 2.13


### PR DESCRIPTION
How would publishing work now that 2.1.1 is already tagged? Can that be triggered just for 2.13.0-RC2 manually?