### PR TITLE
bump sbt-scala-module to 2.2.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "2.2.0")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "2.2.2")


### PR DESCRIPTION
this pulls in an sbt-osgi bump which allows building on JDK 15
(e.g. in the Scala community build)

https://github.com/scala/sbt-scala-module/releases/tag/v2.2.1
https://github.com/scala/sbt-scala-module/releases/tag/v2.2.2