### PR TITLE
fix compile error

### DIFF
--- a/examples/src/main/scala/scala/swing/examples/TableSelection.scala
+++ b/examples/src/main/scala/scala/swing/examples/TableSelection.scala
@@ -16,11 +16,11 @@ import scala.swing._
 import scala.swing.event._
 
 object TableSelection extends SimpleSwingApplication {
-  val model = Array(List("Mary", "Campione", "Snowboarding", 5, false).toArray,
-    List("Alison", "Huml", "Rowing", 5, false).toArray,
-    List("Kathy", "Walrath", "Knitting", 5, false).toArray,
-    List("Sharon", "Zakhour", "Speed reading", 5, false).toArray,
-    List("Philip", "Milne", "Pool", 5, false).toArray)
+  val model = Array(List("Mary", "Campione", "Snowboarding", 5, false).toArray[Any],
+    List("Alison", "Huml", "Rowing", 5, false).toArray[Any],
+    List("Kathy", "Walrath", "Knitting", 5, false).toArray[Any],
+    List("Sharon", "Zakhour", "Speed reading", 5, false).toArray[Any],
+    List("Philip", "Milne", "Pool", 5, false).toArray[Any])
 
   lazy val ui: BoxPanel = new BoxPanel(Orientation.Vertical) {
     val table: Table = new Table(model, Array("First Name", "Last Name", "Sport", "# of Years", "Vegetarian")) {

--- a/examples/src/main/scala/scala/swing/examples/TableSelection.scala
+++ b/examples/src/main/scala/scala/swing/examples/TableSelection.scala
@@ -16,11 +16,11 @@ import scala.swing._
 import scala.swing.event._
 
 object TableSelection extends SimpleSwingApplication {
-  val model = Array(List("Mary", "Campione", "Snowboarding", 5, false).toArray[Any],
-    List("Alison", "Huml", "Rowing", 5, false).toArray[Any],
-    List("Kathy", "Walrath", "Knitting", 5, false).toArray[Any],
-    List("Sharon", "Zakhour", "Speed reading", 5, false).toArray[Any],
-    List("Philip", "Milne", "Pool", 5, false).toArray[Any])
+  val model = Array[Array[Any]](List("Mary", "Campione", "Snowboarding", 5, false).toArray,
+    List("Alison", "Huml", "Rowing", 5, false).toArray,
+    List("Kathy", "Walrath", "Knitting", 5, false).toArray,
+    List("Sharon", "Zakhour", "Speed reading", 5, false).toArray,
+    List("Philip", "Milne", "Pool", 5, false).toArray)
 
   lazy val ui: BoxPanel = new BoxPanel(Orientation.Vertical) {
     val table: Table = new Table(model, Array("First Name", "Last Name", "Sport", "# of Years", "Vegetarian")) {


### PR DESCRIPTION
Nice to meet you. When I run `sbt examples / run` on the work branch, I get the following error:


```
% sbt examples/run
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by sbt.TrapExit$ (file:~/.sbt/boot/scala-2.12.14/org.scala-sbt/sbt/1.5.5/run_2.12-1.5.5.jar)
WARNING: Please consider reporting this to the maintainers of sbt.TrapExit$
WARNING: System::setSecurityManager will be removed in a future release
[info] welcome to sbt 1.5.5 (Homebrew Java 17.0.1)
[info] loading global plugins from ~/.sbt/1.0/plugins
[info] loading settings for project scala-swing-build from plugins.sbt ...
[info] loading project definition from ~/scala-swing/project
[info] loading settings for project swing from build.sbt ...
[info] set current project to scala-swing (in build file:~/scala-swing/)
[info] compiling 52 Scala sources to ~/scala-swing/examples/target/scala-3.0.2/classes ...
[error] -- [E134] Type Error: ~/scala-swing/examples/src/main/scala/scala/swing/examples/TableSelection.scala:26:27 
[error] 26 |    val table: Table = new Table(model, Array("First Name", "Last Name", "Sport", "# of Years", "Vegetarian")) {
[error]    |                           ^^^^^
[error]    |None of the overloaded alternatives of constructor Table in class Table with types
[error]    | (model0: javax.swing.table.TableModel): scala.swing.Table
[error]    | (rows: Int, columns: Int): scala.swing.Table
[error]    | (rowData: Array[Array[Any]], columnNames: collection.Seq[?]): scala.swing.Table
[error]    | (): scala.swing.Table
[error]    |match arguments ((scala.swing.examples.TableSelection.model : Array[Array[Matchable]]), Array[String])
[error] one error found
[error] one error found
[error] (examples / Compile / compileIncremental) Compilation failed
[error] Total time: 4 s, completed 2022/01/30 18:56:32
```

This pull request fixed a compilation error. If you have a better fix, please give me some advice.