### PR TITLE
bump sbt (to 1.7.1), Scala (to 2.12.16, 3.1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.12, 2.12.15, 2.13.8, 3.0.2]
+        scala: [2.11.x, 2.12.x, 2.13.x, 3.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val scalaTestVersion = "3.2.10"
 
-ThisBuild / crossScalaVersions := Seq("3.0.2", "2.13.8", "2.12.15", "2.11.12")
+ThisBuild / crossScalaVersions := Seq("3.1.3", "2.13.8", "2.12.16", "2.11.12")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 // We use <epoch>.<major>.<minor> like 99% of Scala libraries.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.7.1


### PR DESCRIPTION
@Sciss any objections to dropping Scala 3.0 support, requiring users to move to 3.1? many/most libraries are doing this, ecosystem-wide