### PR TITLE
chore(deps): bump sbt and scala versions (drop 2.11)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-lazy val scalaTestVersion = "3.2.10"
+lazy val scalaTestVersion = "3.2.19"
 
-ThisBuild / crossScalaVersions := Seq("3.1.3", "2.13.8", "2.12.16", "2.11.12")
+ThisBuild / crossScalaVersions := Seq("3.3.3", "2.13.14", "2.12.20")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 // We use <epoch>.<major>.<minor> like 99% of Scala libraries.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"   % "3.0.0")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"   % "3.1.0")


### PR DESCRIPTION
Not sure how important 2.11 is but this is otherwise a trivial PR to update dependencies of scalac and plugins.